### PR TITLE
[rfc] Radio: remove duplicate protocol value

### DIFF
--- a/rfc/netjson.xml
+++ b/rfc/netjson.xml
@@ -664,7 +664,7 @@
                     <ttcol>key name</ttcol><ttcol>JSON type</ttcol><ttcol>description</ttcol>
                     <c>name</c><c>string</c><c>arbitrary name of the radio device</c>
                     <c>protocol</c><c>string</c><c>wireless protocol used, the
-                    RECOMMENDED allowed values are: 802.11ac, 802.11n, 802.11b, 802.11g, 802.11n</c>
+                    RECOMMENDED allowed values are: 802.11ac, 802.11n, 802.11b, 802.11g, 802.11a</c>
                     <c>channel</c><c>integer</c><c>channel number</c>
                     <c>channel_width</c><c>integer</c><c>channel width in Hertz</c>
                 </texttable>


### PR DESCRIPTION
In #55 the `protocol` member of the Radio object was introduced but the value `802.11n` is mentioned twice in the list of recommended values. It is removed in this pull request.
Or perhaps it should be `802.11a` because that seems missing from the list? Not sure about the relevance of 11a nowadays though...

As a side note: in my experience a radio usually supports more than one standard for a given frequency band. E.g. a 2.4GHz radio is typically configured for 11b, 11g and 11n at the same time for maximum client compatibility, but it's possible to configure differently. It seems this can currently not be expressed with NetJSON?
Have you ever looked at Broadband Forum's Device:2 data model? Their version of `protocol` would be https://www.broadband-forum.org/cwmp/tr-181-2-11-0.html#D.Device:2.Device.WiFi.Radio.{i}.OperatingStandards